### PR TITLE
Fix where to search copy-media.py

### DIFF
--- a/texinfo2epub.sh
+++ b/texinfo2epub.sh
@@ -28,7 +28,6 @@ if [[ ! -f $INPUT_FILE ]]; then
   exit 1
 fi
 
-CURRENT_PATH=$(pwd)
 INPUT_FILE_PATH=$(cd $(dirname $INPUT_FILE) && pwd)/$(basename $INPUT_FILE)
 OUTPUT_FILE_PATH=$(cd $(dirname $OUTPUT_FILE) && pwd)/$(basename $OUTPUT_FILE)
 SCRIPT_DIR=$(cd $(dirname $0) && pwd)
@@ -41,5 +40,5 @@ makeinfo --docbook $INPUT_FILE_PATH -o out.xml
 xsltproc $EPUB_XSL out.xml
 echo "application/epub+zip" > mimetype
 zip -0Xq $OUTPUT_FILE_PATH mimetype
-$CURRENT_PATH/copy-media.py OEBPS/content.opf $(dirname $INPUT_FILE_PATH)
+$SCRIPT_DIR/copy-media.py OEBPS/content.opf $(dirname $INPUT_FILE_PATH)
 zip -Xr9D $OUTPUT_FILE_PATH META-INF OEBPS


### PR DESCRIPTION
Using $(pwd) is not good enough because the user might be calling texinfo2epub.sh from any directory. Fortunately, the work has already been done properly to get the docbook-xsl-1.79.2/ directory. We just reuse the trick.