### PR TITLE
Update texinfo2epub.sh

### DIFF
--- a/texinfo2epub.sh
+++ b/texinfo2epub.sh
@@ -38,7 +38,7 @@ trap "rm -rf $TMP_DIR" EXIT
 cd $TMP_DIR
 makeinfo --docbook $INPUT_FILE_PATH -o out.xml
 xsltproc $EPUB_XSL out.xml
-echo "application/epub+zip" > mimetype
+echo -n "application/epub+zip" > mimetype
 zip -0Xq $OUTPUT_FILE_PATH mimetype
 $SCRIPT_DIR/copy-media.py OEBPS/content.opf $(dirname $INPUT_FILE_PATH)
 zip -Xr9D $OUTPUT_FILE_PATH META-INF OEBPS


### PR DESCRIPTION
This patch suppresses the trailing linefeed in mimetype, avoiding an error message when validating an output epub by epubcheck.